### PR TITLE
Better doc build dependency checks

### DIFF
--- a/audit_python_package/data/requirements.txt
+++ b/audit_python_package/data/requirements.txt
@@ -2,6 +2,7 @@ alabaster==0.7.7
 appnope==0.1.0
 Babel==2.2.0
 bleach==1.4.2
+CommonMark==0.5.4
 cov-core==1.15.0
 coverage==4.0.3
 decorator==4.0.6
@@ -26,6 +27,7 @@ pytest-catchlog==1.2.2
 pytest-cov==2.2.0
 pytz==2015.7
 readme_renderer==0.7.0
+recommonmark==0.4.0
 setuptools==19.6
 sbo-sphinx==2.2.0
 simplegeneric==0.8.1

--- a/audit_python_package/tests/test_requirements.py
+++ b/audit_python_package/tests/test_requirements.py
@@ -114,6 +114,10 @@ class TestDocumentationRequirements(object):
         """bleach should be pinned to our currently preferred version and appear after html5lib and six"""
         check_version(documentation, 'bleach', {'html5lib', 'six'})
 
+    def test_commonmark_version(self, documentation):
+        """CommonMark should be pinned to our currently preferred version"""
+        check_version(documentation, 'CommonMark')
+
     def test_docutils_version(self, documentation):
         """docutils should be pinned to our currently preferred version"""
         check_version(documentation, 'docutils')
@@ -146,9 +150,13 @@ class TestDocumentationRequirements(object):
         """readme_renderer should be pinned to our currently preferred version and appear after bleach, docutils, Pygments, and six"""
         check_version(documentation, 'readme_renderer', {'bleach', 'docutils', 'Pygments', 'six'})
 
+    def test_recommonmark_version(self, documentation):
+        """recommonmark should be pinned to our currently preferred version and appear after CommonMark and docutils"""
+        check_version(documentation, 'recommonmark', {'docutils', 'CommonMark'})
+
     def test_sbo_sphinx_version(self, documentation):
-        """sbo-sphinx should be pinned to our currently preferred version and appear after Sphinx"""
-        check_version(documentation, 'sbo-sphinx', {'Sphinx'})
+        """sbo-sphinx should be pinned to our currently preferred version and appear after recommonmark and Sphinx"""
+        check_version(documentation, 'sbo-sphinx', {'recommonmark', 'Sphinx'})
 
     def test_six_version(self, documentation):
         """six should be pinned to our currently preferred version"""

--- a/audit_python_package/tests/test_setup.py
+++ b/audit_python_package/tests/test_setup.py
@@ -53,14 +53,14 @@ class TestSetup(object):
         """There should be an invalid "Private :: Do Not Upload" classifier in private packages to prevent accidental uploads to PyPI"""
         assert 'Private :: Do Not Upload' in setup
 
-    def test_read_the_docs(self, setup):
-        """There should be explicit support for Read the Docs builds in setup.py"""
-        assert 'READTHEDOCS' in setup
-        assert 'documentation.txt' in setup
+    def test_no_read_the_docs_section(self, setup):
+        """There should not be explicit support for Read the Docs builds in setup.py (specify a requirements file for the virtualenv in the Read the Docs configuration instead)"""
+        assert 'READTHEDOCS' not in setup
+        assert 'documentation.txt' not in setup
 
     def test_multiple_pip_versions(self, setup):
         """setup.py should work with a good variety of pip versions"""
-        assert 'PipSession()' in setup
-        assert ', session=session)' in setup
-        assert 'str(r.req)' in setup
+        if 'parse_requirements' in setup:
+            assert 'PipSession()' in setup
+            assert ', session=session)' in setup
         assert '[r.req' not in setup

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,11 +3,15 @@ audit-python-package Changelog
 
 1.7.3 (2016-01-27)
 ------------------
-Reversed the check for explicit inclusion of exact dependency versions for doc
-builds in setup.py; this turned out to be prone to version conflicts between
-different installed packages which all do this.  Instead, you should specify
-a requirements file for the virtualenv in your Read the Docs configuration
-for the project.
+* Reversed the check for explicit inclusion of exact dependency versions for
+  doc builds in setup.py; this turned out to be prone to version conflicts
+  between different installed packages which all do this.  Instead, you should
+  specify a requirements file for the virtualenv in your Read the Docs
+  configuration for the project.
+* Added checks for specifying exact versions of CommonMark and recommonmark,
+  which are indirect dependencies of sbo-sphinx.  As of this writing, the
+  latest recommonmark is not compatible with the latest CommonMark release;
+  see https://github.com/rtfd/recommonmark/issues/24 .
 
 1.7.2 (2016-01-26)
 ------------------

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 audit-python-package Changelog
 ==============================
 
+1.7.3 (2016-01-27)
+------------------
+Reversed the check for explicit inclusion of exact dependency versions for doc
+builds in setup.py; this turned out to be prone to version conflicts between
+different installed packages which all do this.  Instead, you should specify
+a requirements file for the virtualenv in your Read the Docs configuration
+for the project.
+
 1.7.2 (2016-01-26)
 ------------------
 * Accommodate the `readme` -> `readme_renderer` package rename

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -3,7 +3,7 @@
 # Indirect dependencies first, exact versions for consistency
 
 # flake8
-mccabe==0.3.1
+mccabe==0.4.0
 pep8==1.7.0
 pyflakes==1.0.0
 

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -2,21 +2,24 @@
 
 # Indirect dependencies to pin for consistency
 
-# readme -> bleach -> html5lib, Sphinx
+# readme_renderer -> bleach -> html5lib, Sphinx
 six==1.10.0
 
-# readme -> bleach
+# readme_renderer -> bleach
 html5lib==0.9999999
 
-# readme
+# readme_renderer
 bleach==1.4.2
 
-# readme, Sphinx
+# readme_renderer, Sphinx
 docutils==0.12
 Pygments==2.1
 
 # Sphinx -> Babel
 pytz==2015.7
+
+# sbo-sphinx -> recommonmark
+CommonMark==0.5.4
 
 # sbo-sphinx -> Sphinx -> Jinja2
 MarkupSafe==0.23
@@ -30,6 +33,7 @@ Jinja2==2.8
 snowballstemmer==1.2.1
 
 # sbo-sphinx
+recommonmark==0.4.0
 Sphinx==1.3.5
 
 # Sphinx themes (circular dependencies of Sphinx)

--- a/setup.py
+++ b/setup.py
@@ -8,28 +8,15 @@ audit-python-package setup script
 from __future__ import unicode_literals
 
 import codecs
-import os
 from setuptools import find_packages, setup
 
-version = '1.7.2'  # Don't forget to update docs/CHANGELOG.rst if you increment the version
+version = '1.7.3'  # Don't forget to update docs/CHANGELOG.rst if you increment the version
 
 install_requires = [
     'pytest-cov',
     'readme',
     'requires.io==0.2.5'
 ]
-
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    from pip.download import PipSession
-    from pip.index import PackageFinder
-    from pip.req import parse_requirements
-    session = PipSession()
-    root_dir = os.path.abspath(os.path.dirname(__file__))
-    requirements_path = os.path.join(root_dir, 'requirements', 'documentation.txt')
-    finder = PackageFinder([], [], session=session)
-    requirements = parse_requirements(requirements_path, finder, session=session)
-    install_requires.extend([str(r.req) for r in requirements if r.match_markers()])
 
 with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()


### PR DESCRIPTION
- Reversed the check for explicit inclusion of exact dependency versions for doc builds in setup.py; this turned out to be prone to version conflicts between different installed packages which all do this.  Instead, you should specify a requirements file for the virtualenv in your Read the Docs configuration for the project.
- Added checks for specifying exact versions of CommonMark and recommonmark, which are indirect dependencies of sbo-sphinx.  As of this writing, the latest recommonmark is not compatible with the latest CommonMark release; see https://github.com/rtfd/recommonmark/issues/24 .
